### PR TITLE
InvocationTargetException on SkipThisScenarioException

### DIFF
--- a/src/org/sliderule/runner/Algorithm.java
+++ b/src/org/sliderule/runner/Algorithm.java
@@ -570,6 +570,12 @@ public class Algorithm {
 					}
 				} catch( SkipThisScenarioException e ) {
 					continue;
+				} catch( InvocationTargetException e ) {
+					Throwable t = e.getCause();
+					if ( t instanceof SkipThisScenarioException ) {
+						continue;
+					}
+					throw e;
 				}
 			}
 			D( "finished all parameter permutations. moving on to next class" );


### PR DESCRIPTION
InvocationTargetException if the invoked method throws an exception. The
SkipThisScenarioException was not properly caught.

Sample stacktrace below.

java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.sliderule.runner.Algorithm.bench(Algorithm.java:552)
    at org.sliderule.runner.Algorithm.evaluate(Algorithm.java:592)
    at org.sliderule.runner.SlideRuleMain.go(SlideRuleMain.java:311)
    at
org.sliderule.runner.SlideRuleMain.main(SlideRuleMain.java:324)
Caused by: org.sliderule.api.SkipThisScenarioException
