### PR TITLE
Fixed NullPointerException issue in sweep chart creation

### DIFF
--- a/src/org/sliderule/runner/GoogleChartsWriter.java
+++ b/src/org/sliderule/runner/GoogleChartsWriter.java
@@ -307,7 +307,7 @@ class GoogleChartsWriter {
 		pw.println( "      var options" + chart_idx + " = {" );
 		pw.println( "        chart: {" );
 		pw.println( "          title: '" + classes.first().getName() + " " + ( micro ? "Micro" : "Macro" ) + "-Benchmark, " + date + "'," );
-		pw.println( "          subtitle: 'Parameters: " + PolymorphicType.nameParams( base_name, base_case ) + "'" );
+		pw.println( "          subtitle: 'Parameters: " + base_name[0].getName() + ":" + base_case[0] + "'" );
 		pw.println( "        }," );
 		pw.println( "        bars: 'horizontal' // Required for Material Bar Charts." );
 		pw.println( "      };" );


### PR DESCRIPTION
Changed call to base_name and base_case so that they only access the first item in the array

This is necessary as base_name and base_case are instantiated with GoogleChartsResultProcessor.extractOneFromArray, which creates an N sized array where the only the first position is populated, and the rest are null.

This throws a null pointer exception when it is called with PolymorphicType.nameParams, as nameParams loops through the array to call getName from the item of the array

The new change does the same thing as nameParams does, but only calls the first item as opposed to concatenating every item in the array.
